### PR TITLE
fix: Nightly build failing to fetch artifacts

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ async function rebuildShards({path}) {
 
 const RepoCrystal = {owner: "crystal-lang", repo: "crystal"};
 const RepoShards = {owner: "crystal-lang", repo: "shards"};
-const CircleApiBase = "https://circleci.com/api/v1.1/project/github/crystal-lang/crystal";
+const CircleApiBase = "https://circleci.com/api/v2/project/github/crystal-lang/crystal";
 
 async function findRelease({name, repo, tag}) {
     if (!(/^\d+\.\d+\.\d\w*$/.test(tag))) {


### PR DESCRIPTION
Update CircleApiBase to use the path to v2 of circleci's API rather than v1.1.

The build artifacts for nightly build 75102 are only available for the URL of v2 of the API, which is currently causing attempts to install the nightly build to fail.

See below:
https://circleci.com/api/v1.1/project/github/crystal-lang/crystal/75102/artifacts
https://circleci.com/api/v2/project/github/crystal-lang/crystal/75102/artifacts