### PR TITLE
Fix pkconfig path lookup using `brew --prefix`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
         exclude:
           - os: windows-latest
             config: {shards: '0.12.0', crystal: '0.35.1'}
+          - os: macos-latest
+            config: {shards: '0.12.0', crystal: '0.35.1'}
 
     name: crystal ${{ matrix.config.crystal }} + shards ${{ matrix.config.shards }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
         exclude:
           - os: windows-latest
             config: {shards: '0.12.0', crystal: '0.35.1'}
+          - os: macos-latest
+            config: {shards: '0.12.0', crystal: '0.35.1'}
 
     name: crystal ${{ matrix.config.crystal }} + shards ${{ matrix.config.shards }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/index.js
+++ b/index.js
@@ -164,8 +164,10 @@ async function installCrystalForMac({crystal, shards, arch = "x86_64", path}) {
         } catch (e) {}
     }
 
+    const {stdout} = await subprocess(["brew", "--prefix"]);
+    const homebrewPrefix = stdout.trim();
     const globber = await Glob.create([
-        "/usr/local/Cellar/openssl*/*/lib/pkgconfig",
+        `${homebrewPrefix}/Cellar/openssl*/*/lib/pkgconfig`,
         "/usr/local/opt/openssl/lib/pkgconfig",
     ].join("\n"));
     let [pkgConfigPath] = await globber.glob();


### PR DESCRIPTION
The homebrew installation directory moved from `/usr/local/Cellar` to `/opt/homebrew/Cellar` in the latest update of the GitHub Actions runner image (https://github.com/actions/runner-images/pull/9728).

The former path was hard coded in the install action, and as a result pkgconfig information for openssl could not be found.

This patch queries `brew --prefix` to get the installation directory.