### PR TITLE
Migrate from node20 to node24 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ outputs:
   path:
     description: The directory where Crystal was installed
 runs:
-  using: node20
+  using: node22
   main: index.js
 branding:
   icon: octagon

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ outputs:
   path:
     description: The directory where Crystal was installed
 runs:
-  using: node22
+  using: node24
   main: index.js
 branding:
   icon: octagon


### PR DESCRIPTION
## Summary
- Update `runs.using` from `node20` to `node24` in action.yml
- Node.js 20 reaches EOL April 2026
- GitHub Actions supports `node20` and `node24` (not `node22`)
- GitHub will force Node.js 24 as default starting June 2, 2026
- The codebase is already ESM (`"type": "module"`) so no other changes needed

## References
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/