### PR TITLE
Support both x86_64-msvc and msvc release asset names

### DIFF
--- a/index.js
+++ b/index.js
@@ -435,7 +435,7 @@ async function installCrystalForWindows({crystal, shards, arch = "x86_64", path}
         if (version) {
             await IO.mv(await downloadCrystalNightlyForWindows(version[1]), path);
         } else {
-            const filePattern = /-windows-x86_64-msvc(-unsupported)?\.zip$/;
+            const filePattern = /-windows-(x86_64-)?msvc(-unsupported)?\.zip$/;
             await installBinaryRelease({crystal, shards, filePattern, path});
         }
     }


### PR DESCRIPTION
This is an attempt to fix #75.
Because Windows MSVC binary release asset names exist in both formats (x86_64-msvc and msvc), I updated the asset selection pattern to support both.