### PR TITLE
Handle missing asset error in Crystal download

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,7 +348,7 @@ async function downloadCrystalRelease(filePattern, version = null) {
 
     const asset = release["assets"].find((a) => filePattern.test(a["name"]));
     if (!asset) {
-        Core.error("No asset found!");
+        Core.error(`No asset found matching "${filePattern}" for Crystal release ${release["tag_name"]}!`);
         process.exit(1);
     }
 

--- a/index.js
+++ b/index.js
@@ -347,6 +347,10 @@ async function downloadCrystalRelease(filePattern, version = null) {
     Core.setOutput("crystal", release["tag_name"]);
 
     const asset = release["assets"].find((a) => filePattern.test(a["name"]));
+    if (!asset) {
+        Core.error("No asset found!");
+        process.exit(1);
+    }
 
     Core.info(`Downloading Crystal build from ${asset["url"]}`);
     const resp = await github.request({


### PR DESCRIPTION
Gracefully handle missing release assets.

```
Run crystal-lang/install-crystal@v1
Looking for crystal-lang/crystal-lang release (latest)
Getting Crystal release (1.20.1)
Found Crystal release https://github.com/crystal-lang/crystal/releases/tag/1.20.1
Error: TypeError: Cannot read properties of undefined (reading 'url')
```

https://github.com/Sija/backtracer.cr/actions/runs/25135736682/job/73674101265

* References #12